### PR TITLE
Enable creation of agents without tools

### DIFF
--- a/pocket_agent/agent.py
+++ b/pocket_agent/agent.py
@@ -311,6 +311,9 @@ class PocketAgent:
         tools = await self.mcp_client.get_tools(format="openai")
         if not tools:
             self.logger.debug("No tools found, LLM response will be generated without tools")
+            # remove tool_choice from kwargs if it exists
+            if "tool_choice" in kwargs:
+                del kwargs["tool_choice"]
         else:
             kwargs.update({
                 "tools": tools,

--- a/pocket_agent/agent.py
+++ b/pocket_agent/agent.py
@@ -140,9 +140,9 @@ class PocketAgent:
         self._run_lock = asyncio.Lock()
 
         if not mcp_config and not sub_agents:
-            error_message = "MCP config is empty and no sub agents are provided. At least one of the two must be provided."
-            self.logger.error(error_message)
-            raise ValueError(error_message)
+            self.logger.debug("MCP config is empty and no sub agents are provided. \
+                The agent will be initialized with no tools.")
+            mcp_config = FastMCP()
         
         self.mcp_config = mcp_config
         self.sub_agents = sub_agents
@@ -284,8 +284,6 @@ class PocketAgent:
 
 
                         
-
-
     def create_wrapper_with_context(self, func: Callable) -> Callable:
         async def wrapper(*args, **kwargs):
             hook_context = self._create_hook_context()
@@ -311,9 +309,12 @@ class PocketAgent:
         kwargs.update(override_completion_kwargs)
         messages = self._format_messages()
         tools = await self.mcp_client.get_tools(format="openai")
-        kwargs.update({
-            "tools": tools,
-        })
+        if not tools:
+            self.logger.debug("No tools found, LLM response will be generated without tools")
+        else:
+            kwargs.update({
+                "tools": tools,
+            })
         try:
             self.logger.debug(f"Requesting LLM response with kwargs={kwargs}")
             response = await self.llm_completion_handler.acompletion(

--- a/pocket_agent/docs/02_core-concepts.md
+++ b/pocket_agent/docs/02_core-concepts.md
@@ -14,7 +14,7 @@ class MyAgent(PocketAgent):
 ```python
 agent = PocketAgent(
     agent_config,   # Required: (AgentConfig) Instance of the AgentConfig class
-    mcp_config,     # Optional (if sub_agents provided; Required otherwise): (dict or FastMCP) MCP Server or JSON MCP server configuration to pass tools to the agent
+    mcp_config,     # Optional: (dict or FastMCP) MCP Server or JSON MCP server configuration to pass tools to the agent
     router,         # Optional: A LiteLLM router instance to manage llm rate limits
     logger,         # Optional: A logger instance to capture logs
     hooks,          # Optional: (AgentHooks) optionally define custom behavior at common junction points

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pocket-agent"
-version = "0.2.21"
+version = "0.2.22"
 description = "A lightweight, extensible framework for building LLM agents with Model Context Protocol (MCP) support"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pocket-agent"
-version = "0.2.22"
+version = "0.2.23"
 description = "A lightweight, extensible framework for building LLM agents with Model Context Protocol (MCP) support"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -8,6 +8,7 @@ from pocket_agent.agent import (
 from litellm.types.utils import ModelResponse, Message, Choices, Usage
 import os
 import asyncio
+from fastmcp import FastMCP
 
 
 class SimpleTestAgent(PocketAgent):
@@ -417,17 +418,17 @@ class TestPocketAgentMultiAgent:
         assert agent.mcp_client is not None
         assert agent.sub_agents[0].is_sub_agent is True
 
-    def test_agent_fails_when_neither_config_provided(self, simple_config):
+    def test_agent_works_when_neither_config_provided(self, simple_config):
         """Test that agent fails when neither mcp_config nor sub_agents are provided"""
-        with pytest.raises(ValueError) as exc_info:
-            SimpleTestAgent(
+        agent = SimpleTestAgent(
                 agent_config=simple_config,
                 mcp_config=None,
                 sub_agents=None
             )
         
-        assert "MCP config is empty and no sub agents are provided" in str(exc_info.value)
-        assert "At least one of the two must be provided" in str(exc_info.value)
+        assert agent.mcp_client is not None
+        assert type(agent.mcp_config) is FastMCP
+        assert agent.sub_agents is None
 
     def test_agent_works_with_both_mcp_config_and_sub_agents(self, simple_config, sub_agent_config, simple_mcp_config):
         """Test that agent works when both mcp_config and sub_agents are provided"""

--- a/uv.lock
+++ b/uv.lock
@@ -1905,7 +1905,7 @@ wheels = [
 
 [[package]]
 name = "pocket-agent"
-version = "0.2.21"
+version = "0.2.23"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1905,7 +1905,7 @@ wheels = [
 
 [[package]]
 name = "pocket-agent"
-version = "0.2.2"
+version = "0.2.21"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
This adds support for using pocket agent as a simpler way to do regular llm completions without agent behaviors (i.e. interaction with tools)