### PR TITLE
Add Structured Responses to Pocket Agent

### DIFF
--- a/pocket_agent/agent.py
+++ b/pocket_agent/agent.py
@@ -550,10 +550,10 @@ class PocketAgent:
                     await self.add_user_message(
                         "Please return your last result with the JSON Schema format specified."
                     )
-                    structured_response_result = await self._get_llm_response(
+                    step_result = await self.step(
                         **response_format_dict
                     )
-                    return structured_response_result
+                    return step_result.llm_message.content
                 else:
                     self.logger.warning(
                         "JSON Schema is not supported for model "

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -598,7 +598,7 @@ class TestAgentIntegration:
 
         assert mock_router.acompletion.call_count == 3
 
-        parsed = MultiplicationResponseSchema.model_validate_json(result.choices[0].message.content)
+        parsed = MultiplicationResponseSchema.model_validate_json(result)
         assert parsed.a == 2
         assert parsed.b == 3
         assert parsed.result == 6


### PR DESCRIPTION
### SUMMARY
This pull request adds support for structured responses using response schemas, enabling the agent to return results in a specified JSON format upon request. It also introduces new integration tests to verify this functionality.

Aims to fix #17 

### CHANGES

`agent.py`
* In order to enforce the structured outputs, we need to ensure the LLM is done calling all of its tools and the rest of its thinking and responses are finished, only then should we solicit a structured final response that adhres to a schema. To do this, I modified the `run` method of PocketAgent to make an additional call to the LLM if a response schema is passed
* Given that not all models support response schemas, if the user passes a model that is incapable of generating structured responses, we still return the unstructured response and log this as a warning

`test_integration.py`
* Implemented the `test_response_schema_handling` integration test to ensure that the agent returns a structured response matching a specified Pydantic schema and verifies the correct call sequence to the LLM.